### PR TITLE
Add Maru image placeholder

### DIFF
--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: temporalio/maru
+  # Build your Maru image based on worker/Dockerfile and put its name and tag below
+  repository: <your-maru-image>
   tag: latest
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## What was changed:

Maru container image `temporalio/maru` is replaced with a placeholder and a relevant note

## Why?

The official image is not available right now, so it's better to be explicit that the image has to be built by the consumer.

## Checklist

1. Closes issue: closes #24
