### PR TITLE
Update helm chart to use the new docker image

### DIFF
--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   # Build your Maru image based on worker/Dockerfile and put its name and tag below
-  repository: <your-maru-image>
+  repository: ghcr.io/temporalio/maru
   tag: latest
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Signed-off-by: Mark Sagi-Kazar <mark.sagikazar@gmail.com>

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Update helm chart to use the new docker image

## Why?
So that the Helm chart can be used out of the box and doesn't need a custom image

## Checklist
<!--- add/delete as needed --->

1. Related #24

2. How was this tested:
Helm chart install

3. Any docs updates needed?
NONE
