### PR TITLE
Updated tctl commands to include namespace flag in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ easily experiment with running different sizes of Kubernetes clusters.
 Once the bench worker and target workflows are running, you can start a quick test with the following command
 
 ```
-tctl wf start --tq temporal-bench --wt bench-workflow --wtt 5 --et 1800 --if ./scenarios/basic-test.json --wid 1
+tctl --namespace benchtest wf start --tq temporal-bench --wt bench-workflow --wtt 5 --et 1800 --if ./scenarios/basic-test.json --wid 1
 ```
 
 This command starts a basic Bench workflow which in turns runs the Basic workflow six times. If everything is configured correctly, you should be able to see those workflows in Web UI:
@@ -54,7 +54,7 @@ This command starts a basic Bench workflow which in turns runs the Basic workflo
 The Bench workflow returns the statistics of the workflow execution. You can query the workflow to retrieve execution statistics with the following command
 
 ```
-$ tctl wf query --qt histogram --wid 1
+$ tctl --namespace benchtest wf query --qt histogram --wid 1
 Query result:
 [[{"started":6,"closed":6,"backlog":0}]]
 ```
@@ -66,7 +66,7 @@ The workflow completed almost instantaneously, so there is just one data point. 
 Here is a sample test that runs a steady workload of 20 workflows per second for 10 minutes:
 
 ```
-tctl wf start --tq temporal-bench --wt bench-workflow --wtt 5 --et 1800 --if ./scenarios/basic-const12k.json --wid 2
+tctl --namespace benchtest wf start --tq temporal-bench --wt bench-workflow --wtt 5 --et 1800 --if ./scenarios/basic-const12k.json --wid 2
 ```
 
 It runs 12,000 workflows in total. The scenario also sets the reporting interval to 10 seconds, which means that the resulting report will have data points for every 10-second interval.
@@ -76,7 +76,7 @@ It runs 12,000 workflows in total. The scenario also sets the reporting interval
 Execute the `histogram` query to retrieve the execution statistics
 
 ```
-$ tctl wf query --qt histogram --wid 2
+$ tctl --namespace benchtest wf query --qt histogram --wid 2
 Query result:
 [[{"started":200,"closed":200,"backlog":0},{"started":200,"closed":200,"backlog":0},
 {"started":200,"closed":200,"backlog":0},{"started":200,"closed":200,"backlog":0},
@@ -88,7 +88,7 @@ The result is a JSON array of execution statistics, where each array item repres
 You can also retrieve the same information printed as a CSV file with the `histrogram_csv` query
 
 ```
-$ tctl wf query --qt histogram_csv --wid 2
+$ tctl --namespace benchtest wf query --qt histogram_csv --wid 2
 Query result:
 [Time (seconds);Workflows Started;Workflows Started Rate;Workflow Closed;Workflow Closed Rate;Backlog
 10;200;20.000000;200;20.000000;0
@@ -110,7 +110,7 @@ If you have Prometheus installed and configured to listen at `http://prometheus-
 you can use an additional query to retrieve the metrics of storage and History service utilization:
 
 ```
-tctl wf query --qt metrics_csv --wid 2
+tctl --namespace benchtest wf query --qt metrics_csv --wid 2
 Query result:
 [Time (seconds);Persistence Latency (ms);History Service Latency (ms);Persistence CPU (mcores);History Service CPU (mcores);History Service Memory Working Set (MB)
 60;8;456;494;418;27


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Updated `tctl` commands to include namespace flag in README.md.

## Why?
Since the workers are listing for `benchtest` namespace. Running `tctl` commands without a namespace flag would not result in any data and all the commands would be pointing to the default namespace. Workers will not be picking up the workflows.

## Checklist

1. Any docs updates needed?
README.md is updated to include namespace flag with `benchtest`