### PR TITLE
Make target task queue configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Here are all the parameters you may configure:
 - `steps[i].ratePerSecond` - The maximum number of workflow executions to start per second (rate limiting). By default, no rate limiting applies.
 - `steps[i].concurrency` - The number of parallel activities that bench will use to start target workflows. Can be useful when `ratePerSecond` is too high for a single activity to keep up. Defaults to `ratePerSecond` divided by `10`.
 - `workflow.name` - The name of a workflow to be used as the testing target. The bench will start `step[*].count` of these workflows.
-- `workflow.taskQueue` - The name of a task queue to use when starting the target workflow.
+- `workflow.taskQueue` - The name of the task queue to use when starting the target workflow.
 - `workflow.args` - Arguments to send to the target workflows. This must match the shape of the target workflow's inputs.
 - `report.intervalInSeconds` - The resolution of execution statistics in the resulting report. Defaults to 1 minute.
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ You can tweak the parameters of the benchmark scenario by adjusting the JSON fil
     }],
     "workflow": {
         "name": "basic-workflow",
+        "taskQueue": "temporal-basic",
         "args": {
             "sequenceCount": 3,
             "parallelCount": 1
@@ -166,6 +167,7 @@ Here are all the parameters you may configure:
 - `steps[i].ratePerSecond` - The maximum number of workflow executions to start per second (rate limiting). By default, no rate limiting applies.
 - `steps[i].concurrency` - The number of parallel activities that bench will use to start target workflows. Can be useful when `ratePerSecond` is too high for a single activity to keep up. Defaults to `ratePerSecond` divided by `10`.
 - `workflow.name` - The name of a workflow to be used as the testing target. The bench will start `step[*].count` of these workflows.
+- `workflow.taskQueue` - The name of a task queue to use when starting the target workflow.
 - `workflow.args` - Arguments to send to the target workflows. This must match the shape of the target workflow's inputs.
 - `report.intervalInSeconds` - The resolution of execution statistics in the resulting report. Defaults to 1 minute.
 
@@ -179,6 +181,7 @@ Here is the definition of the workflow in `./scenarios/basic-payload.json`:
 ```json
 "workflow": {
     "name": "basic-workflow",
+    "taskQueue": "temporal-basic",
     "args": {
         "sequenceCount": 3,
         "payload": "$RANDOM(100)",

--- a/scenarios/basic-const12k.json
+++ b/scenarios/basic-const12k.json
@@ -6,6 +6,7 @@
     }],
     "workflow": {
         "name": "basic-workflow",
+        "taskQueue": "temporal-basic",
         "args": {
             "sequenceCount": 3
         }

--- a/scenarios/basic-payload.json
+++ b/scenarios/basic-payload.json
@@ -5,6 +5,7 @@
     }],
     "workflow": {
         "name": "basic-workflow",
+        "taskQueue": "temporal-basic",
         "args": {
             "sequenceCount": 3,
             "payload": "$RANDOM(100)",

--- a/scenarios/basic-spike.json
+++ b/scenarios/basic-spike.json
@@ -12,6 +12,7 @@
     }],
     "workflow": {
         "name": "basic-workflow",
+        "taskQueue": "temporal-basic",
         "args": {
             "sequenceCount": 3
         }

--- a/scenarios/basic-test.json
+++ b/scenarios/basic-test.json
@@ -5,6 +5,7 @@
     }],
     "workflow": {
         "name": "basic-workflow",
+        "taskQueue": "temporal-basic",
         "args": {
             "sequenceCount": 3
         }

--- a/worker/bench/activities.go
+++ b/worker/bench/activities.go
@@ -37,9 +37,6 @@ func NewActivities(temporalClient client.Client) *Activities {
 // benchTaskQueue is the queue used by worker to pull workflow and activity tasks
 const benchTaskQueue = "temporal-bench"
 
-// targetTaskQueue is the queue used by worker to schedule target workflows
-const targetTaskQueue = "temporal-basic"
-
 // TestError represents an error that should abort / fail the whole bench test
 type TestError struct {
 	Message string

--- a/worker/bench/driver_activity.go
+++ b/worker/bench/driver_activity.go
@@ -46,11 +46,12 @@ func (a *Activities) DriverActivity(ctx context.Context, request benchDriverActi
 
 type (
 	benchDriverActivityRequest struct {
-		WorkflowName string
-		BaseID       string
-		BatchSize    int
-		Rate         int
-		Parameters   interface{}
+		WorkflowName  string
+		TaskQueueName string
+		BaseID        string
+		BatchSize     int
+		Rate          int
+		Parameters    interface{}
 	}
 	benchDriver struct {
 		ctx     context.Context
@@ -113,7 +114,7 @@ func (d *benchDriver) execute(iterationID int) error {
 	workflowID := fmt.Sprintf("%s-%s-%d", d.request.WorkflowName, d.request.BaseID, iterationID)
 	startOptions := client.StartWorkflowOptions{
 		ID:                       workflowID,
-		TaskQueue:                targetTaskQueue,
+		TaskQueue:                d.request.TaskQueueName,
 		WorkflowExecutionTimeout: 30 * time.Minute,
 		WorkflowTaskTimeout:      defaultWorkflowTaskStartToCloseTimeoutDuration,
 	}

--- a/worker/bench/workflow.go
+++ b/worker/bench/workflow.go
@@ -66,6 +66,8 @@ type (
 	benchWorkflowRequestWorkflow struct {
 		// Name is the name of the workflow to run for benchmarking (workflow under test).
 		Name string `json:"name"`
+		// TaskQueue is the name of the task queue to use when executing the workflow.
+		TaskQueue string `json:"taskqueue"`
 		// Args is the argument that should be the input of all executions of the workflow under test.
 		Args interface{} `json:"args"`
 	}
@@ -156,11 +158,12 @@ func (w *benchWorkflow) executeDriverActivities(stepIndex int, step benchWorkflo
 			w.withActivityOptions(),
 			"bench-DriverActivity",
 			benchDriverActivityRequest{
-				BaseID:       fmt.Sprintf("%s-%d-%d", w.baseID, stepIndex, i),
-				BatchSize:    step.Count / concurrency,
-				Rate:         step.RatePerSecond / concurrency,
-				WorkflowName: w.request.Workflow.Name,
-				Parameters:   w.request.Workflow.Args,
+				BaseID:        fmt.Sprintf("%s-%d-%d", w.baseID, stepIndex, i),
+				BatchSize:     step.Count / concurrency,
+				Rate:          step.RatePerSecond / concurrency,
+				WorkflowName:  w.request.Workflow.Name,
+				TaskQueueName: w.request.Workflow.TaskQueue,
+				Parameters:    w.request.Workflow.Args,
 			}))
 	}
 


### PR DESCRIPTION
## What was changed

Makes the target task queue name configurable through the scenario definition.

## Why?

So the target workflow can be executed by a different worker from the maru worker.

## Checklist

1. Closes temporalio/maru#45

2. How was this tested:

Run maru worker.
Run [hello-world sample](https://github.com/temporalio/samples-typescript/tree/main/hello-world) worker.
Create a new scenario definition:
```
{
    "steps": [{
        "count": 10,
        "concurrency": 2
    }],
    "workflow": {
        "name": "example",
        "taskQueue": "hello-world",
        "args": "Temporal"
    }
}
```
Start a new benchmark: `tctl --namespace benchtest wf start --tq temporal-bench --wt bench-workflow --wtt 5 --et 1800 --if ./scenarios/hello-world.json --wid hello`

3. Any docs updates needed?

I've updated the "Configure your own scenario" section in the README.