### PR TITLE
make prometheus url configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The driver application reads the following environment variables to connect to a
 ```
 NAMESPACE=default
 FRONTEND_ADDRESS=127.0.0.1:7233
+PROMETHEUS_URL=http://prometheus-server
 ```
 
 You will need to run the bench application, which also acts as a Temporal worker. Use the makefile to do so:
@@ -46,8 +47,7 @@ easily experiment with running different sizes of Kubernetes clusters.
 
 Once the bench worker and target workflows are running, you can start a quick test with the following command
 
-* Note: make sure you run this command in the base directory of your cloned maru repository (not the worker directory
-  where you started the worker earlier). 
+* Note: make sure you run this command in the base directory of your cloned maru repository (not the worker directory where you started the worker earlier).
 
 ```
 tctl wf start --tq temporal-bench --wt bench-workflow --wtt 5 --et 1800 --if ./scenarios/basic-test.json --wid 1
@@ -114,7 +114,7 @@ For example, save the CSV to a file, upload it to from Google Spreadsheets, and 
 
 ## Retrieve the metrics
 
-If you have Prometheus installed and configured to listen at `http://prometheus-server`,
+If you have Prometheus installed and configured, you can pass its URL via `PROMETHEUS_URL` environment variable (default: `http://prometheus-server`),
 you can use an additional query to retrieve the metrics of storage and History service utilization:
 
 ```

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -67,7 +67,8 @@ spec:
               value: "{{ .Values.tests.skipNamespaceCreation }}"
             - name: RUN_WORKERS
               value: "{{ .Values.workers }}"
-
+            - name: PROMETHEUS_URL
+              value: "{{ .Values.tests.prometheusURL }}"
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -17,6 +17,7 @@ tests:
   namespaceName: benchtest
   namespaceRetention: "1"
   frontendAddress: temporaltest-frontend:7233
+  prometheusURL: "http://prometheus-server"
   numDecisionPollers: 50
   skipNamespaceCreation: false
   caCertFile: ""
@@ -27,7 +28,7 @@ tests:
   caCertData: ""
   clientCertData: ""
   clientCertPrivateKeyData: ""
-  
+
   enableHostVerification: false
 
 imagePullSecrets: []

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -12,6 +12,7 @@ NAMESPACE ?= benchtest
 NAMESPACE_RETENTION ?= 1
 FRONTEND_ADDRESS ?= 127.0.0.1:7233
 NUM_DECISION_POLLERS ?= 10
+PROMETHEUS_URL ?= http://prometheus-server
 
 DOCKER_IMAGE ?= temporal-bench
 DOCKER_IMAGE_TAG := $(shell whoami | tr -d " ")-local
@@ -38,6 +39,7 @@ run: bins
 	NAMESPACE_RETENTION=$(NAMESPACE_RETENTION) \
 	FRONTEND_ADDRESS=$(FRONTEND_ADDRESS) \
 	NUM_DECISION_POLLERS=$(NUM_DECISION_POLLERS) \
+	PROMETHEUS_URL=$(PROMETHEUS_URL) \
 	bins/temporal-bench
 
 docker-image:


### PR DESCRIPTION
Signed-off-by: Mariia Kotliarevskaia <mariia.kotliarevskaia@gmail.com>

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
make prometheus url configurable via env variable: `PROMETHEUS_URL`

## Why?
<!-- Tell your future self why have you made these changes -->

I have prometheus installed in the separate namespace and don't want to install worker chart there. 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- `kubectl port-forward -n prometheus svc/prometheus-server 12345:80`
- `export PROMETHEUS_URL=127.0.0.1:12345`
- `make run`
- run workflow from README
- retrieve data via `tctl wf query --qt metrics_csv --wid N`
output is:
```
["Time (seconds);Persistence Latency (ms);History Service Latency (ms);Persistence CPU (mcores);History Service CPU (mcores);History Service Memory Working Set (MB)\n10;3;;;25;1531\n20;3;;;99;1535\n30;19;44;;99;1535\n40;19;44;;99;1535\n50;19;44;;99;1535...
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
      
updated README.md + helm-chart configuration
