### PR TITLE
Enable custom pod annotations

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
         prometheus.io/job: {{ $.Chart.Name }}
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9090'
+        {{- with $.Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -93,3 +93,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+podAnnotations: {}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Allows users to define custom pod level annotations 

## Why?
<!-- Tell your future self why have you made these changes -->
This unlocks the capbility to provide additional configuration option for external systems (e.g. istio sidecar resources) 
## Checklist
<!--- add/delete as needed --->

How was this tested:
Validated charts being generated with annotations when configured.  


with podAnnotations :
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: maru-temporal-bench
  labels:
    ...
spec:
  replicas: 2
  selector:
    matchLabels:
      app.kubernetes.io/name: temporal-bench
      app.kubernetes.io/instance: maru
  template:
    metadata:
      labels:
        app.kubernetes.io/name: temporal-bench
        app.kubernetes.io/instance: maru
      annotations:
        prometheus.io/job: temporal-bench
        prometheus.io/scrape: 'true'
        prometheus.io/port: '9090'
        sidecar.istio.io/proxyCPU: 200m
        sidecar.istio.io/proxyMemory: 512Mi
        sidecar.istio.io/proxyMemoryLimit: 512Mi
```

without annotations
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: maru-temporal-bench
  labels:
    ...
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: temporal-bench
      app.kubernetes.io/instance: maru
  template:
    metadata:
      labels:
        app.kubernetes.io/name: temporal-bench
        app.kubernetes.io/instance: maru
      annotations:
        prometheus.io/job: temporal-bench
        prometheus.io/scrape: 'true'
        prometheus.io/port: '9090'
```
<!--- Please describe how you tested your changes/how we can test them -->
